### PR TITLE
Make it possible to expect std::exception

### DIFF
--- a/include/tut/tut_macros.hpp
+++ b/include/tut/tut_macros.hpp
@@ -13,23 +13,31 @@
  *  ensure_THROW( this_function_should_throw_bad_alloc(), std::bad_alloc );
  * \endcode
  */
-#define ensure_THROW( x, e ) \
-try         \
-{           \
-    x;      \
-    fail(#x " has not thrown expected exception " #e); \
-}                \
-catch(const e &) \
-{                \
-}                \
-catch(const std::exception &ex)  \
-{           \
-    fail( std::string(#x " has thrown unexpected exception ")+tut::type_name(ex)+": "+ex.what()); \
-} \
-catch(...)       \
-{                \
-    fail(#x " has thrown unexpected unknown exception"); \
-}
+#define ensure_THROW(x, e) \
+do                                                                         \
+{                                                                          \
+    try                                                                    \
+    {                                                                      \
+        try                                                                \
+        {                                                                  \
+            x;                                                             \
+        }                                                                  \
+        catch (const e&)                                                   \
+        {                                                                  \
+            break;                                                         \
+        }                                                                  \
+    }                                                                      \
+    catch (const std::exception& ex)                                       \
+    {                                                                      \
+        fail(std::string(#x " has thrown unexpected exception ") +         \
+             tut::type_name(ex) + ": " + ex.what());                       \
+    }                                                                      \
+    catch (...)                                                            \
+    {                                                                      \
+        fail(#x " has thrown unexpected unknown exception");               \
+    }                                                                      \
+    fail(#x " has not thrown expected exception " #e);                     \
+} while (false)
 
 #ifdef ensure_NO_THROW
 #error ensure_NO_THROW macro is already defined

--- a/selftest/ensure_throw.cpp
+++ b/selftest/ensure_throw.cpp
@@ -29,6 +29,15 @@ namespace
     {
         throw foo_exception();
     }
+
+    void throw_std()
+    {
+        throw std::runtime_error("some std::exception");
+    }
+
+    void noop()
+    {
+    }
 }
 
 template<>
@@ -83,6 +92,42 @@ void object::test<3>()
         if (std::string(ex.what()).find("skip()") == std::string::npos )
         {
             fail("no_throw doesn't contain proper message");
+        }
+    }
+}
+
+template<>
+template<>
+void object::test<4>()
+{
+    set_test_name("checks throw std::exception");
+
+    try
+    {
+        ensure_THROW( throw_std(), std::exception );
+    }
+    catch (const failure& ex)
+    {
+        fail("positive throw expecting std::exception doesn't work");
+    }
+}
+
+template<>
+template<>
+void object::test<5>()
+{
+    set_test_name("checks throw std::exception");
+
+    try
+    {
+        ensure_THROW( noop(), std::exception );
+        fail("throw doesn't work");
+    }
+    catch (const failure& ex)
+    {
+        if (std::string(ex.what()).find("noop()") == std::string::npos )
+        {
+            fail("throw doesn't contain proper message");
         }
     }
 }


### PR DESCRIPTION
Macro ensure_THROW would not handle std::exception nicely, as it was assumed to
be an unexpected exception. Specifying is as the expected exception type caused
compilation warning, because the same try-catch block was handling both cases.

I've fixed that by using a nested try-catch block. The inner one is supposed to
check if the proper exception type is thrown. The outer block catches unexpected
exception types.
