### PR TITLE
bug: ensure_equals now works correctly with floating numbers

### DIFF
--- a/include/tut/tut_assert.hpp
+++ b/include/tut/tut_assert.hpp
@@ -190,6 +190,89 @@ void ensure_equals(const LHS& actual, const RHS& expected)
     ensure_equals("Values are not equal", actual, expected);
 }
 
+template<typename M, typename VALUE>
+void ensure_isnan(const M& msg, const VALUE& val)
+{
+	if (!std::isnan(val))
+	{
+		std::ostringstream ss;
+		detail::msg_prefix(ss, msg)
+			<< std::scientific
+			<< std::showpoint
+			<< std::setprecision(16)
+			<< "value: `" << val << "`";
+		throw failure(ss.str());
+	}
+}
+
+template <typename VALUE>
+void ensure_isnan(const VALUE& val)
+{
+	ensure_isnan("Value is a valid number (not a NaN)", val);
+}
+
+template<typename M, typename VALUE>
+void ensure_not_isnan(const M& msg, const VALUE& val)
+{
+	if (std::isnan(val))
+	{
+		std::ostringstream ss;
+		detail::msg_prefix(ss, msg)
+			<< std::scientific
+			<< std::showpoint
+			<< std::setprecision(16)
+			<< "value: `" << val << "`";
+		throw failure(ss.str());
+	}
+}
+
+template <typename VALUE>
+void ensure_not_isnan(const VALUE& val)
+{
+	ensure_not_isnan("Value is not a valid number (NaN)", val);
+}
+
+template<typename M, typename VALUE>
+void ensure_isinf(const M& msg, const VALUE& val)
+{
+	if (!std::isinf(val))
+	{
+		std::ostringstream ss;
+		detail::msg_prefix(ss, msg)
+			<< std::scientific
+			<< std::showpoint
+			<< std::setprecision(16)
+			<< "value: `" << val << "`";
+		throw failure(ss.str());
+	}
+}
+
+template <typename VALUE>
+void ensure_isinf(const VALUE& val)
+{
+	ensure_isinf("Value is not infinity", val);
+}
+
+template<typename M, typename VALUE>
+void ensure_isfinite(const M& msg, const VALUE& val)
+{
+	if (!std::isfinite(val))
+	{
+		std::ostringstream ss;
+		detail::msg_prefix(ss, msg)
+			<< std::scientific
+			<< std::showpoint
+			<< std::setprecision(16)
+			<< "value: `" << val << "`";
+		throw failure(ss.str());
+	}
+}
+
+template <typename VALUE>
+void ensure_isfinite(const VALUE& val)
+{
+	ensure_isfinite("Value is not a finite number (infinity)", val);
+}
 
 template<typename LhsIterator, typename RhsIterator>
 void ensure_equals(const std::string &msg,

--- a/include/tut/tut_assert.hpp
+++ b/include/tut/tut_assert.hpp
@@ -8,6 +8,10 @@
 #include <cassert>
 #include <cmath>
 
+#if __cplusplus >= 201103L
+#include <type_traits>
+#endif
+
 #if defined(TUT_USE_POSIX)
 #include <errno.h>
 #include <cstring>
@@ -92,7 +96,12 @@ void ensure_not(const M& msg, bool cond)
  * client code will not compile at all!
  */
 template <typename M, typename LHS, typename RHS>
-void ensure_equals(const M& msg, const LHS& actual, const RHS& expected)
+#if __cplusplus >= 201103L
+typename std::enable_if<!std::is_floating_point<LHS>::value && !std::is_floating_point<RHS>::value, void>::type
+#else
+void
+#endif
+    ensure_equals(const M& msg, const LHS& actual, const RHS& expected)
 {
     if (expected != actual)
     {
@@ -130,12 +139,22 @@ void ensure_equals(const M& msg, const LHS * const actual, const RHS * const exp
     }
 }
 
+#if __cplusplus >= 201103L
+template<typename M, typename LHS, typename RHS, typename EPS>
+typename std::enable_if<std::is_floating_point<LHS>::value || std::is_floating_point<RHS>::value, void>::type
+    ensure_equals(const M& msg, const LHS& actual, const RHS& expected, const EPS& epsilon)
+{
+	if((actual != expected)
+		&& (std::isnan(actual) || std::isnan(expected)
+		|| (std::abs(actual - expected) > epsilon)
+		|| (std::abs(actual - expected) < std::numeric_limits<EPS>::min())))
+#else
 template<typename M>
 void ensure_equals(const M& msg, const double& actual, const double& expected, const double& epsilon)
 {
-    const double diff = actual - expected;
-
-    if ( (actual != expected) && !((diff <= epsilon) && (diff >= -epsilon )) )
+	const double diff = actual - expected;
+	if ((actual != expected) && !((diff <= epsilon) && (diff >= -epsilon)))
+#endif
     {
         std::ostringstream ss;
         detail::msg_prefix(ss,msg)
@@ -149,10 +168,20 @@ void ensure_equals(const M& msg, const double& actual, const double& expected, c
     }
 }
 
+#if __cplusplus >= 201103L
+template<typename M, typename LHS, typename RHS>
+typename std::enable_if<std::is_floating_point<LHS>::value || std::is_floating_point<RHS>::value, void>::type
+    ensure_equals(const M& msg, const LHS& actual, const RHS& expected)
+{
+	auto epsilon = sizeof(LHS) < sizeof(RHS) ? std::numeric_limits<LHS>::epsilon() : std::numeric_limits<RHS>::epsilon();
+# else
 template<typename M>
 void ensure_equals(const M& msg, const double& actual, const double& expected)
 {
-    ensure_equals(msg, actual, expected, std::numeric_limits<double>::epsilon());
+	double epsilon = std::numeric_limits<double>::epsilon();
+#endif
+
+    ensure_equals(msg, actual, expected, epsilon * std::abs(actual + expected));
 }
 
 template <typename LHS, typename RHS>

--- a/selftest/ensure_equals.cpp
+++ b/selftest/ensure_equals.cpp
@@ -147,9 +147,9 @@ template<>
 template<>
 void object::test<13>()
 {
-    double lhs = 6.28;
-    double rhs = 3.14;
-    lhs /= 2;
+    double lhs = 1000000.;
+    double rhs = 200000.;
+    lhs = lhs / std::sqrt(5) / std::sqrt(5);
 
     ensure_equals("double==double", lhs, rhs);
 }
@@ -167,7 +167,7 @@ void object::test<14>()
 
     try
     {
-        ensure_equals(lhs + 2*std::numeric_limits<double>::epsilon(), rhs);
+        ensure_equals(lhs + 10*std::numeric_limits<double>::epsilon(), rhs);
         throw runtime_error("double!=double");
     }
     catch (const failure &ex)
@@ -379,5 +379,24 @@ void object::test<20>()
     }
 }
 
+/**
+* Checks positive ensure_equals with mixing floating point types (float + double)
+*/
+template<>
+template<>
+void object::test<21>()
+{
+#if __cplusplus < 201103L
+    skip();
+#endif
+
+    float flhs = 1000000., frhs = 200000.;
+    double drhs = 200000., dlhs = 1000000.;
+    flhs = flhs / std::sqrt(5) / std::sqrt(5);
+    dlhs = dlhs / std::sqrt(5) / std::sqrt(5);
+
+    ensure_equals("float==double", flhs, drhs);
+    ensure_equals("double==float", dlhs, frhs);
 }
 
+}

--- a/selftest/ensure_isnan_isinf.cpp
+++ b/selftest/ensure_isnan_isinf.cpp
@@ -1,0 +1,75 @@
+#include <tut/tut.hpp>
+
+#include <limits>
+
+namespace tut
+{
+	/**
+	* Testing ensure() method.
+	*/
+	struct ensure_isnan_isinf_test
+	{
+		virtual ~ensure_isnan_isinf_test()
+		{
+		}
+	};
+
+	typedef test_group<ensure_isnan_isinf_test> tf;
+	typedef tf::object object;
+	tf ensure_isnan_isinf_test("ensure_isnan_isinf");
+
+	/**
+	* Checks ensure_isnan
+	*/
+	template<>
+	template<>
+	void object::test<1>()
+	{
+		set_test_name("checks ensure_isnan");
+
+		double zero = 0.;
+		ensure_isnan("ok", 0. / zero);
+		ensure_isnan(std::numeric_limits<double>::quiet_NaN());
+	}
+
+	/**
+	* Checks ensure_not_isnan
+	*/
+	template<>
+	template<>
+	void object::test<2>()
+	{
+		set_test_name("checks ensure_not_isnan");
+
+		ensure_not_isnan("ok", 12.);
+		ensure_not_isnan(std::numeric_limits<double>::infinity());
+	}
+
+	/**
+	* Checks ensure_isinf
+	*/
+	template<>
+	template<>
+	void object::test<3>()
+	{
+		set_test_name("checks ensure_isinf");
+
+		double zero = 0.;
+		ensure_isinf("ok", 1. / zero);
+		ensure_isinf("ok", -1. / zero);
+		ensure_isinf(std::numeric_limits<double>::infinity());
+	}
+
+	/**
+	* Checks ensure_isfinite
+	*/
+	template<>
+	template<>
+	void object::test<4>()
+	{
+		set_test_name("checks ensure_isfinite");
+
+		ensure_isfinite("ok", 12.);
+		ensure_isfinite(1000000);
+	}
+}


### PR DESCRIPTION
To compare 2 floating points, we need to take care of the epsilon of the machine.
On top of that, the precision of a double depends on the length of the radix (the bigger it is, the less information can be stored in the floating part).

Thus, I've updated the comparison between 2 floating points values according to http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon (see the example code).

- fix comparison between doubles when the radix is big
- fix comparison between long doubles (before they were cast in double with possible wrong comparison)
    - this is now a templated function

I've updated the tests, I'm not quiet familiar yet with this library so don't hesitate to correct my code or tell me if I'm doing wrong stuff...