### PR TITLE
Fix waf build script for Python 3

### DIFF
--- a/waftools/gcov.py
+++ b/waftools/gcov.py
@@ -13,7 +13,7 @@ def Wrapper(script):
     wrapper = NamedTemporaryFile(delete=False)
     wrapper.write(script)
     wrapper.close()
-    os.chmod(wrapper.name, 0777)
+    os.chmod(wrapper.name, 0o777)
 
     yield wrapper.name
 


### PR DESCRIPTION
`tut` builds fine with Python 2, but when I try to install it with Python 3, I see the following error message:
```
  File "waftools/gcov.py", line 16
    os.chmod(wrapper.name, 0777)
                              ^
SyntaxError: invalid token
```
In Python 2, integers that start with a leading 0 are interpreted as octals. In Python 3, this is not the case, and the number must start with 0o or else it will be a SyntaxError. This patch allows me to build tut with Python 3. I also confirmed that it still works for Python 2. All build tests pass.

Is this file written by you or generated by `waf`? Just wondering if I also need to submit a bug report with them.