### PR TITLE
tut_assert: use noreturn function attribute

### DIFF
--- a/include/tut/tut_assert.hpp
+++ b/include/tut/tut_assert.hpp
@@ -12,6 +12,12 @@
 #include <type_traits>
 #endif
 
+#if __cplusplus >= 201103L
+#define TUT_NORETURN [[noreturn]]
+#else
+#define TUT_NORETURN
+#endif
+
 #if defined(TUT_USE_POSIX)
 #include <errno.h>
 #include <cstring>
@@ -385,13 +391,13 @@ void ensure_errno(const M& msg, bool cond)
 /**
  * Unconditionally fails with message.
  */
-static inline void fail(const char* msg = "")
+TUT_NORETURN static inline void fail(const char* msg = "")
 {
     throw failure(msg);
 }
 
 template<typename M>
-void fail(const M& msg)
+TUT_NORETURN void fail(const M& msg)
 {
     throw failure(msg);
 }
@@ -399,13 +405,13 @@ void fail(const M& msg)
 /**
  * Mark test case as known failure and skip execution.
  */
-static inline void skip(const char* msg = "")
+TUT_NORETURN static inline void skip(const char* msg = "")
 {
     throw skipped(msg);
 }
 
 template<typename M>
-void skip(const M& msg)
+TUT_NORETURN void skip(const M& msg)
 {
     throw skipped(msg);
 }


### PR DESCRIPTION
These functions never return. They throw an exception. Add the C++ 11
noreturn function attribute to help compiler.

For the following code the compiler

    int f() {
        tut::fail("hello");
    }

emits a warning:

    In function ‘int f()’:
    warning: no return statement in function returning non-void [-Wreturn-type]

But this warning is a false postive. The code is actually correct,
because the function never returns normally.

With this patch the compiler does not produce this false-postive.